### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A Model Context Protocol server that provides read and write access to Airtable 
 
 https://github.com/user-attachments/assets/b4b42c1e-857b-4226-b4ff-edafda9de141
 
+<a href="https://glama.ai/mcp/servers/7abwib27hk"><img width="380" height="200" src="https://glama.ai/mcp/servers/7abwib27hk/badge" /></a>
+
 ## Usage
 
 To use this server with the Claude Desktop app, add the following configuration to the "mcpServers" section of your `claude_desktop_config.json`:


### PR DESCRIPTION
This PR adds a badge for the `airtable-mcp-server` server listing in Glama MCP server directory.

https://glama.ai/mcp/servers/7abwib27hk

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.