### PR TITLE
feat: Add detailLevel argument to list_tables, and add describe_table

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,17 @@ Replace `pat123.abc123` with your [Airtable personal access token](https://airta
   - Lists all tables in a specific base
   - Input parameters:
     - `baseId` (string, required): The ID of the Airtable base
-  - Returns table ID, name, description, fields, and views
+    - `detailLevel` (string, optional): The amount of detail to get about the tables (`tableIdentifiersOnly`, `identifiersOnly`, or `full`)
+  - Returns table ID, name, description, fields, and views (to the given `detailLevel`)
+
+- **describe_table**
+  - Gets detailed information about a specific table
+  - Input parameters:
+    - `baseId` (string, required): The ID of the Airtable base
+    - `tableId` (string, required): The ID of the table to describe
+    - `detailLevel` (string, optional): The amount of detail to get about the table (`tableIdentifiersOnly`, `identifiersOnly`, or `full`)
+  - Returns the same format as list_tables but for a single table
+  - Useful for getting details about a specific table without fetching information about all tables in the base
 
 - **get_record**
   - Gets a specific record by ID

--- a/src/types.ts
+++ b/src/types.ts
@@ -471,8 +471,27 @@ export const SearchRecordsArgsSchema = z.object({
   maxRecords: z.number().optional().describe('Maximum number of records to return. Defaults to 100.'),
 });
 
+export const TableDetailLevelSchema = z.enum(['tableIdentifiersOnly', 'identifiersOnly', 'full']).describe(`Detail level for table information:
+- tableIdentifiersOnly: table IDs and names
+- identifiersOnly: table, field, and view IDs and names
+- full: complete details including field types, descriptions, and configurations
+
+Note for LLMs: To optimize context window usage, request the minimum detail level needed:
+- Use 'tableIdentifiersOnly' when you only need to list or reference tables
+- Use 'identifiersOnly' when you need to work with field or view references
+- Only use 'full' when you need field types, descriptions, or other detailed configuration
+
+If you only need detailed information on a few tables in a base with many complex tables, it might be more efficient for you to use list_tables with tableIdentifiersOnly, then describe_table with full on the specific tables you want.`);
+
+export const DescribeTableArgsSchema = z.object({
+  baseId: z.string(),
+  tableId: z.string(),
+  detailLevel: TableDetailLevelSchema.optional().default('full'),
+});
+
 export const ListTablesArgsSchema = z.object({
   baseId: z.string(),
+  detailLevel: TableDetailLevelSchema.optional().default('full'),
 });
 
 export const GetRecordArgsSchema = z.object({


### PR DESCRIPTION
This enables us to better support large bases without running out of context/truncating output (one of the base schemas at @bluedotimpact is ~300,000 characters 😅)