### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ WORKDIR /app
 # Copy the build files from the previous stage
 COPY --from=builder /app/dist /app/dist
 COPY --from=builder /app/package.json /app/package-lock.json 
-COPY --from=builder /app/node_modules /app/node_modules
-
+RUN npm install
 # Set the entry point to run the server
 ENTRYPOINT ["node", "dist/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ WORKDIR /app
 
 # Copy the build files from the previous stage
 COPY --from=builder /app/dist /app/dist
-COPY --from=builder /app/package.json /app/package-lock.json /app/node_modules /app/
+COPY --from=builder /app/package.json /app/package-lock.json 
+COPY --from=builder /app/node_modules /app/node_modules
 
 # Set the entry point to run the server
 ENTRYPOINT ["node", "dist/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ WORKDIR /app
 
 # Copy the build files from the previous stage
 COPY --from=builder /app/dist /app/dist
-COPY --from=builder /app/package.json /app/package-lock.json 
-RUN npm install
+COPY --from=builder /app/package.json /app/package.json 
+COPY --from=builder /app/node_modules /app/node_modules
+
 # Set the entry point to run the server
 ENTRYPOINT ["node", "dist/index.js"]


### PR DESCRIPTION
* This pull request includes a minor update to the `Dockerfile`. 
* Previous version of the Dockerfile generated an image that was throwing an error on start

to repro error: 

`docker build -t airtable-mcp . `

```
docker run -ti --rm airtable-mcp
node:internal/errors:496
    ErrorCaptureStackTrace(err);
    ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@modelcontextprotocol/sdk' imported from /app/dist/index.js
    at new NodeError (node:internal/errors:405:5)
    at packageResolve (node:internal/modules/esm/resolve:916:9)
    at moduleResolve (node:internal/modules/esm/resolve:973:20)
    at defaultResolve (node:internal/modules/esm/resolve:1206:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:404:12)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:373:25)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:250:38)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:76:39)
    at link (node:internal/modules/esm/module_job:75:36) {
  code: 'ERR_MODULE_NOT_FOUND'
}

Node.js v18.20.8
```