### PR TITLE
tests: Add docker and dxt tests

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,21 @@
+name: Docker Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout ${{ github.sha }}
+        uses: actions/checkout@v4
+      
+      - name: Install dependencies
+        run: npm ci
+      
+      - name: Build and test Docker image
+        run: npm run test -- 'src/e2e.test.ts'
+        env:
+          RUN_DOCKER_TEST: TRUE

--- a/.github/workflows/dxt.yaml
+++ b/.github/workflows/dxt.yaml
@@ -10,38 +10,44 @@ jobs:
   build-dxt:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    env:
-      CI: true
+    strategy:
+      matrix:
+        # 22 because it's built-in to Claude Desktop
+        node-version: [lts/*, current, '22']
     steps:
       - name: Checkout ${{ github.sha }}
         uses: actions/checkout@v4
       
-      - name: Use Node.js LTS
+      - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: ${{ matrix.node-version }}
           cache: 'npm'
       
       - name: Install dependencies
         run: npm ci
       
-      - name: Build DXT package
-        run: ./build-dxt.sh
+      - name: Build and test DXT package
+        run: npm run test -- 'src/e2e.test.ts'
+        env:
+          RUN_DXT_TEST: TRUE
       
-      # This unzipping is necessary as a workaround for https://github.com/actions/upload-artifact/issues/39
+      # Only upload artifacts and release assets from the LTS build to avoid duplicates
       - name: Prepare artifact
+        if: matrix.node-version == 'lts/*'
         run: |
-          mkdir .github/tmp
+          mkdir -p .github/tmp
           unzip airtable-mcp-server.dxt -d .github/tmp
       
       - name: Publish DXT artifact
+        if: matrix.node-version == 'lts/*'
         uses: actions/upload-artifact@v4
         with:
           name: airtable-mcp-server-dxt
           path: .github/tmp/*
       
       - name: Upload DXT package as release asset
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' && matrix.node-version == 'lts/*'
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -11,424 +11,378 @@ import type {
   ReadResourceResult,
 } from '@modelcontextprotocol/sdk/types.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { execSync, spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { AirtableMCPServer } from './mcpServer.js';
 import { AirtableService } from './airtableService.js';
 
-// Run me with:
-// AIRTABLE_API_KEY=pat1234.abcd RUN_INTEGRATION=TRUE npm run test -- 'src/e2e.test.ts'
-(process.env.RUN_INTEGRATION ? describe : describe.skip)('AirtableMCPServer Integration', () => {
-  let server: AirtableMCPServer;
-  let serverTransport: InMemoryTransport;
-  let clientTransport: InMemoryTransport;
+// Readonly API key for integration tests
+const AIRTABLE_API_KEY = 'patDAZ0YDQu7LqGSy.f4736bbdec6ea0cb8ba8b5dba80c53f8b80e46d78a046a1769e749596671e677';
 
-  beforeEach(async () => {
-    const apiKey = process.env.AIRTABLE_API_KEY;
-    if (!apiKey) {
-      throw new Error('AIRTABLE_API_KEY environment variable is required for integration tests');
+interface MCPClient {
+  sendRequest: <T>(message: JSONRPCRequest) => Promise<T>;
+  close: () => Promise<void>;
+}
+
+/**
+ * Creates an MCP client that communicates with a spawned process via stdin/stdout
+ */
+function createProcessBasedClient(
+  serverProcess: ReturnType<typeof spawn>,
+  timeoutMs: number,
+  cleanup?: () => void,
+): MCPClient {
+  let requestId = 1;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const pendingRequests = new Map<string, { resolve:(value: any) => void; reject: (error: any) => void }>();
+
+  // Handle server responses
+  serverProcess.stdout?.on('data', (data) => {
+    const lines = data.toString().split('\n').filter((line: string) => line.trim());
+    // eslint-disable-next-line no-restricted-syntax
+    for (const line of lines) {
+      try {
+        const response = JSON.parse(line);
+        if (response.id && pendingRequests.has(response.id)) {
+          const { resolve, reject } = pendingRequests.get(response.id)!;
+          pendingRequests.delete(response.id);
+          if ('result' in response) {
+            resolve(response.result);
+          } else if ('error' in response) {
+            reject(new Error(response.error.message || 'Unknown error'));
+          }
+        }
+      } catch (e) {
+        // Ignore non-JSON lines
+      }
     }
-
-    const airtableService = new AirtableService(apiKey);
-    server = new AirtableMCPServer(airtableService);
-    [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
-    await server.connect(serverTransport);
   });
 
   const sendRequest = async <T>(message: JSONRPCRequest): Promise<T> => {
     return new Promise((resolve, reject) => {
-      // Set up response handler
-      clientTransport.onmessage = (response: JSONRPCMessage) => {
-        const typedResponse = response as JSONRPCResponse;
-        if ('result' in typedResponse) {
-          resolve(typedResponse.result as T);
-          return;
-        }
-        reject(new Error('No result in response'));
-      };
+      // eslint-disable-next-line no-plusplus
+      const id = (requestId++).toString();
+      const requestWithId = { ...message, id };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      pendingRequests.set(id, { resolve: resolve as any, reject: reject as any });
 
-      clientTransport.send(message);
+      try {
+        serverProcess.stdin?.write(`${JSON.stringify(requestWithId)}\n`);
+      } catch (e) {
+        pendingRequests.delete(id);
+        reject(e);
+      }
+
+      // Timeout
+      setTimeout(() => {
+        if (pendingRequests.has(id)) {
+          pendingRequests.delete(id);
+          reject(new Error('Request timeout'));
+        }
+      }, timeoutMs);
     });
   };
 
-  test('should list available tools', async () => {
-    const result = await sendRequest<ListToolsResult>({
-      jsonrpc: '2.0',
-      id: '1',
-      method: 'tools/list',
-      params: {},
-    });
+  return {
+    sendRequest,
+    close: async () => {
+      try {
+        serverProcess.kill();
+      } catch (e) {
+        // Process might already be dead
+      }
+      // Run any additional cleanup
+      if (cleanup) {
+        cleanup();
+      }
+    },
+  };
+}
 
-    expect(result.tools.map((t) => t.name)).toMatchInlineSnapshot(`
-      [
-        "list_records",
-        "search_records",
-        "list_bases",
-        "list_tables",
-        "describe_table",
-        "get_record",
-        "create_record",
-        "update_records",
-        "delete_records",
-        "create_table",
-        "update_table",
-        "create_field",
-        "update_field",
-      ]
-    `);
-    expect(result.tools[0]).toMatchObject({
-      name: 'list_records',
-      description: expect.any(String),
-      inputSchema: expect.objectContaining({
-        type: 'object',
-      }),
-    });
-  });
+/**
+ * Main test suite that runs the same tests across different deployment methods
+ */
+describe.each([
+  {
+    name: 'InMemory Transport',
+    condition: true,
+    createClient: async (): Promise<MCPClient> => {
+      const airtableService = new AirtableService(AIRTABLE_API_KEY);
+      const server = new AirtableMCPServer(airtableService);
+      const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+      await server.connect(serverTransport);
 
-  test('should list bases', async () => {
-    const result = await sendRequest<CallToolResult>({
-      jsonrpc: '2.0',
-      id: '1',
-      method: 'tools/call',
-      params: {
-        name: 'list_bases',
-        arguments: {},
-      },
-    });
+      const sendRequest = async <T>(message: JSONRPCRequest): Promise<T> => {
+        return new Promise((resolve, reject) => {
+          clientTransport.onmessage = (response: JSONRPCMessage) => {
+            const typedResponse = response as JSONRPCResponse;
+            if ('result' in typedResponse) {
+              resolve(typedResponse.result as T);
+              return;
+            }
+            reject(new Error('No result in response'));
+          };
+          clientTransport.send(message);
+        });
+      };
 
-    expect(result).toMatchObject({
-      content: [{
-        type: 'text',
-        mimeType: 'application/json',
-        text: expect.any(String),
-      }],
-      isError: false,
-    });
+      return {
+        sendRequest,
+        close: async () => server.close(),
+      };
+    },
+  },
+  {
+    name: 'DXT Package',
+    condition: process.env.RUN_DXT_TEST,
+    createClient: async (): Promise<MCPClient> => {
+      // Build DXT package if it doesn't exist
+      if (!existsSync('airtable-mcp-server.dxt')) {
+        execSync('./build-dxt.sh', { stdio: 'inherit' });
+      }
 
-    const content = JSON.parse(result.content[0]!.text as string);
-    expect(Array.isArray(content)).toBe(true);
-    expect(content.length).toBeGreaterThan(0);
-    expect(content[0]).toMatchObject({
-      id: expect.any(String),
-      name: expect.any(String),
-      permissionLevel: expect.any(String),
-    });
-  });
+      // Extract DXT package to test directory
+      const testDir = 'test-dxt-client';
+      execSync(`rm -rf ${testDir}`);
+      execSync(`mkdir -p ${testDir} && unzip -q airtable-mcp-server.dxt -d ${testDir}`);
 
-  test('should list tables in a base', async () => {
-    // First get a base ID
-    const basesResult = await sendRequest<CallToolResult>({
-      jsonrpc: '2.0',
-      id: '1',
-      method: 'tools/call',
-      params: {
-        name: 'list_bases',
-        arguments: {},
-      },
-    });
+      // Start the MCP server from the extracted DXT package
+      const serverProcess = spawn('node', [path.join(testDir, 'dist/index.js')], {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: { ...process.env, AIRTABLE_API_KEY },
+      });
 
-    const bases = JSON.parse(basesResult.content[0]!.text as string);
-    expect(bases.length).toBeGreaterThan(0);
-    const baseId = bases[0]!.id;
-
-    // Then list tables
-    const result = await sendRequest<CallToolResult>({
-      jsonrpc: '2.0',
-      id: '2',
-      method: 'tools/call',
-      params: {
-        name: 'list_tables',
-        arguments: {
-          baseId,
+      return createProcessBasedClient(
+        serverProcess,
+        10000, // 10 second timeout
+        () => {
+          // Clean up test directory
+          if (fs.existsSync(testDir)) {
+            execSync(`rm -rf ${testDir}`);
+          }
         },
-      },
+      );
+    },
+  },
+  {
+    name: 'Docker Container',
+    condition: process.env.RUN_DOCKER_TEST,
+    createClient: async (): Promise<MCPClient> => {
+      // Build Docker image
+      execSync('docker build -t airtable-mcp-server:test .', { stdio: 'inherit' });
+
+      // Start the MCP server in a Docker container
+      const serverProcess = spawn('docker', [
+        'run', '--rm', '-i',
+        '-e', `AIRTABLE_API_KEY=${AIRTABLE_API_KEY}`,
+        'airtable-mcp-server:test',
+      ], {
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      return createProcessBasedClient(
+        serverProcess,
+        15000, // 15 second timeout (Docker might be slower)
+      );
+    },
+  },
+])('MCP Server Tests - $name', ({ name, condition, createClient }) => {
+  (condition ? describe : describe.skip)(`${name} Integration`, () => {
+    let client: MCPClient;
+
+    beforeEach(async () => {
+      client = await createClient();
     });
 
-    expect(result).toMatchObject({
-      content: [{
-        type: 'text',
-        mimeType: 'application/json',
-        text: expect.any(String),
-      }],
-      isError: false,
+    afterEach(async () => {
+      if (client) {
+        await client.close();
+      }
     });
 
-    const content = JSON.parse(result.content[0]!.text as string);
-    expect(Array.isArray(content)).toBe(true);
-    if (content.length > 0) {
-      expect(content[0]).toMatchObject({
+    test('should list available tools', async () => {
+      const result = await client.sendRequest<ListToolsResult>({
+        jsonrpc: '2.0',
+        id: '1',
+        method: 'tools/list',
+        params: {},
+      });
+
+      expect(result.tools.map((t) => t.name)).toEqual([
+        'list_records',
+        'search_records',
+        'list_bases',
+        'list_tables',
+        'describe_table',
+        'get_record',
+        'create_record',
+        'update_records',
+        'delete_records',
+        'create_table',
+        'update_table',
+        'create_field',
+        'update_field',
+      ]);
+      expect(result.tools[0]).toMatchObject({
+        name: 'list_records',
+        description: expect.any(String),
+        inputSchema: expect.objectContaining({
+          type: 'object',
+        }),
+      });
+    });
+
+    test('should list bases, tables, and records', async () => {
+      // First get bases
+      const basesResult = await client.sendRequest<CallToolResult>({
+        jsonrpc: '2.0',
+        id: '1',
+        method: 'tools/call',
+        params: {
+          name: 'list_bases',
+          arguments: {},
+        },
+      });
+
+      expect(basesResult).toMatchObject({
+        content: [{
+          type: 'text',
+          mimeType: 'application/json',
+          text: expect.any(String),
+        }],
+        isError: false,
+      });
+
+      const bases = JSON.parse(basesResult.content[0]!.text as string);
+      expect(Array.isArray(bases)).toBe(true);
+      expect(bases.length).toBeGreaterThan(0);
+      expect(bases[0]).toMatchObject({
         id: expect.any(String),
+        name: expect.any(String),
+        permissionLevel: expect.any(String),
+      });
+
+      const baseId = bases[0]!.id;
+
+      // Then list tables in the first base
+      const tablesResult = await client.sendRequest<CallToolResult>({
+        jsonrpc: '2.0',
+        id: '2',
+        method: 'tools/call',
+        params: {
+          name: 'list_tables',
+          arguments: {
+            baseId,
+          },
+        },
+      });
+
+      expect(tablesResult).toMatchObject({
+        content: [{
+          type: 'text',
+          mimeType: 'application/json',
+          text: expect.any(String),
+        }],
+        isError: false,
+      });
+
+      const tables = JSON.parse(tablesResult.content[0]!.text as string);
+      expect(Array.isArray(tables)).toBe(true);
+      if (tables.length > 0) {
+        expect(tables[0]).toMatchObject({
+          id: expect.any(String),
+          name: expect.any(String),
+          fields: expect.any(Array),
+        });
+
+        const tableId = tables[0]!.id;
+
+        // Finally list records in the first table
+        const recordsResult = await client.sendRequest<CallToolResult>({
+          jsonrpc: '2.0',
+          id: '3',
+          method: 'tools/call',
+          params: {
+            name: 'list_records',
+            arguments: {
+              baseId,
+              tableId,
+              maxRecords: 10,
+            },
+          },
+        });
+
+        expect(recordsResult).toMatchObject({
+          content: [{
+            type: 'text',
+            mimeType: 'application/json',
+            text: expect.any(String),
+          }],
+          isError: false,
+        });
+
+        const records = JSON.parse(recordsResult.content[0]!.text as string);
+        expect(Array.isArray(records)).toBe(true);
+        if (records.length > 0) {
+          expect(records[0]).toMatchObject({
+            id: expect.any(String),
+            fields: expect.any(Object),
+          });
+        }
+      } else {
+        // eslint-disable-next-line no-console
+        console.warn('Skipping list_records test as no tables found');
+      }
+    });
+
+    test('should list and read resources', async () => {
+      // First list resources
+      const listResult = await client.sendRequest<ListResourcesResult>({
+        jsonrpc: '2.0',
+        id: '1',
+        method: 'resources/list',
+        params: {},
+      });
+
+      expect(listResult).toMatchObject({
+        resources: expect.any(Array),
+      });
+
+      if (listResult.resources.length === 0) {
+        // eslint-disable-next-line no-console
+        console.warn('Skipping resource read test as no resources found');
+        return;
+      }
+
+      // Then read the first resource
+      const resource = listResult.resources[0]!;
+      const readResult = await client.sendRequest<ReadResourceResult>({
+        jsonrpc: '2.0',
+        id: '2',
+        method: 'resources/read',
+        params: {
+          uri: resource.uri,
+        },
+      });
+
+      expect(readResult).toMatchObject({
+        contents: [{
+          uri: resource.uri,
+          mimeType: 'application/json',
+          text: expect.any(String),
+        }],
+      });
+
+      const content = JSON.parse(readResult.contents[0]!.text as string);
+
+      expect(content).toMatchObject({
+        baseId: expect.any(String),
+        tableId: expect.any(String),
         name: expect.any(String),
         fields: expect.any(Array),
       });
-    }
-  });
-
-  test('should list records in a table', async () => {
-    // First get a base ID
-    const basesResult = await sendRequest<CallToolResult>({
-      jsonrpc: '2.0',
-      id: '1',
-      method: 'tools/call',
-      params: {
-        name: 'list_bases',
-        arguments: {},
-      },
     });
-
-    const bases = JSON.parse(basesResult.content[0]!.text as string);
-    expect(bases.length).toBeGreaterThan(0);
-    const baseId = bases[0]!.id;
-
-    // Then get a table ID
-    const tablesResult = await sendRequest<CallToolResult>({
-      jsonrpc: '2.0',
-      id: '2',
-      method: 'tools/call',
-      params: {
-        name: 'list_tables',
-        arguments: {
-          baseId,
-        },
-      },
-    });
-
-    const tables = JSON.parse(tablesResult.content[0]!.text as string);
-    if (tables.length === 0) {
-      // eslint-disable-next-line no-console
-      console.warn('Skipping list_records test as no tables found');
-      return;
-    }
-    const tableId = tables[0]!.id;
-
-    // Finally list records
-    const result = await sendRequest<CallToolResult>({
-      jsonrpc: '2.0',
-      id: '3',
-      method: 'tools/call',
-      params: {
-        name: 'list_records',
-        arguments: {
-          baseId,
-          tableId,
-          maxRecords: 10,
-        },
-      },
-    });
-
-    expect(result).toMatchObject({
-      content: [{
-        type: 'text',
-        mimeType: 'application/json',
-        text: expect.any(String),
-      }],
-      isError: false,
-    });
-
-    const content = JSON.parse(result.content[0]!.text as string);
-    expect(Array.isArray(content)).toBe(true);
-    if (content.length > 0) {
-      expect(content[0]).toMatchObject({
-        id: expect.any(String),
-        fields: expect.any(Object),
-      });
-    }
-  });
-
-  test('should list records from a view', async () => {
-    // First get a base ID
-    const basesResult = await sendRequest<CallToolResult>({
-      jsonrpc: '2.0',
-      id: '1',
-      method: 'tools/call',
-      params: {
-        name: 'list_bases',
-        arguments: {},
-      },
-    });
-
-    const bases = JSON.parse(basesResult.content[0]!.text as string);
-    expect(bases.length).toBeGreaterThan(0);
-    const baseId = bases[0]!.id;
-
-    // Then get a table ID and view ID
-    const tablesResult = await sendRequest<CallToolResult>({
-      jsonrpc: '2.0',
-      id: '2',
-      method: 'tools/call',
-      params: {
-        name: 'list_tables',
-        arguments: {
-          baseId,
-          detailLevel: 'full',
-        },
-      },
-    });
-
-    const tables = JSON.parse(tablesResult.content[0]!.text as string);
-    if (tables.length === 0 || !tables[0]?.views || tables[0]?.views.length === 0) {
-      // eslint-disable-next-line no-console
-      console.warn('Skipping list_records_from_view test as no tables or views found');
-      return;
-    }
-
-    const tableId = tables[0]!.id;
-    const viewId = tables[0]!.views[0]!.id;
-
-    // List records from the view
-    const result = await sendRequest<CallToolResult>({
-      jsonrpc: '2.0',
-      id: '3',
-      method: 'tools/call',
-      params: {
-        name: 'list_records',
-        arguments: {
-          baseId,
-          tableId,
-          view: viewId,
-          maxRecords: 10,
-        },
-      },
-    });
-
-    expect(result).toMatchObject({
-      content: [{
-        type: 'text',
-        mimeType: 'application/json',
-        text: expect.any(String),
-      }],
-      isError: false,
-    });
-
-    const content = JSON.parse(result.content[0]!.text as string);
-    expect(Array.isArray(content)).toBe(true);
-    // Records might be empty if the view has filters that exclude all records
-    if (content.length > 0) {
-      expect(content[0]).toMatchObject({
-        id: expect.any(String),
-        fields: expect.any(Object),
-      });
-    }
-  });
-
-  test('should search records with view filtering', async () => {
-    // First get a base ID
-    const basesResult = await sendRequest<CallToolResult>({
-      jsonrpc: '2.0',
-      id: '1',
-      method: 'tools/call',
-      params: {
-        name: 'list_bases',
-        arguments: {},
-      },
-    });
-
-    const bases = JSON.parse(basesResult.content[0]!.text as string);
-    expect(bases.length).toBeGreaterThan(0);
-    const baseId = bases[0]!.id;
-
-    // Then get a table ID and view ID
-    const tablesResult = await sendRequest<CallToolResult>({
-      jsonrpc: '2.0',
-      id: '2',
-      method: 'tools/call',
-      params: {
-        name: 'list_tables',
-        arguments: {
-          baseId,
-          detailLevel: 'full',
-        },
-      },
-    });
-
-    const tables = JSON.parse(tablesResult.content[0]!.text as string);
-    if (tables.length === 0 || !tables[0]?.views || tables[0]?.views.length === 0) {
-      // eslint-disable-next-line no-console
-      console.warn('Skipping search_records_with_view test as no tables or views found');
-      return;
-    }
-
-    const tableId = tables[0]!.id;
-    const viewId = tables[0]!.views[0]!.id;
-
-    // Search records using the view
-    const result = await sendRequest<CallToolResult>({
-      jsonrpc: '2.0',
-      id: '3',
-      method: 'tools/call',
-      params: {
-        name: 'search_records',
-        arguments: {
-          baseId,
-          tableId,
-          view: viewId,
-          searchTerm: 'a', // Using a common letter to increase chances of finding matches
-          maxRecords: 10,
-        },
-      },
-    });
-
-    expect(result).toMatchObject({
-      content: [{
-        type: 'text',
-        mimeType: 'application/json',
-        text: expect.any(String),
-      }],
-      isError: false,
-    });
-
-    const content = JSON.parse(result.content[0]!.text as string);
-    expect(Array.isArray(content)).toBe(true);
-    // Records might be empty if no matches or if the view has filters that exclude all records
-  });
-
-  test('should list and read resources', async () => {
-    // First list resources
-    const listResult = await sendRequest<ListResourcesResult>({
-      jsonrpc: '2.0',
-      id: '1',
-      method: 'resources/list',
-      params: {},
-    });
-
-    expect(listResult).toMatchObject({
-      resources: expect.any(Array),
-    });
-
-    if (listResult.resources.length === 0) {
-      // eslint-disable-next-line no-console
-      console.warn('Skipping resource read test as no resources found');
-      return;
-    }
-
-    // Then read the first resource
-    const resource = listResult.resources[0]!;
-    const readResult = await sendRequest<ReadResourceResult>({
-      jsonrpc: '2.0',
-      id: '2',
-      method: 'resources/read',
-      params: {
-        uri: resource.uri,
-      },
-    });
-
-    expect(readResult).toMatchObject({
-      contents: [{
-        uri: resource.uri,
-        mimeType: 'application/json',
-        text: expect.any(String),
-      }],
-    });
-
-    const content = JSON.parse(readResult.contents[0]!.text as string);
-
-    expect(content).toMatchObject({
-      baseId: expect.any(String),
-      tableId: expect.any(String),
-      name: expect.any(String),
-      fields: expect.any(Array),
-    });
-  });
-
-  afterEach(async () => {
-    await server.close();
   });
 });


### PR DESCRIPTION
Fixes #40
Fixes #41

### Changes:
- **Added Docker workflow** (`.github/workflows/docker.yaml`): New CI job to build and test Docker images on push/PR
- **Enhanced DXT workflow** (`.github/workflows/dxt.yaml`): 
  - Renamed from `build-dxt.yaml` for clarity
  - Added Node.js matrix testing (LTS, current, and v22)
  - Integrated e2e testing into the build process
  - Optimized artifact uploads to only run on LTS builds
- **Improved e2e tests** (`src/e2e.test.ts`):
  - Refactored from in-memory transport to process-based testing
  - Added support for both Docker and DXT testing via environment variables
  - Simplified test structure and improved reliability
  - Added readonly API key for consistent integration testing

### Benefits:
- Better CI coverage across multiple Node.js versions
- Docker containerization support for easier deployment
- More robust end-to-end testing that better reflects real-world usage
- Reduced CI artifact duplication