### PR TITLE
Increase test timeouts for e2e tests

### DIFF
--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -229,7 +229,7 @@ describe.each([
           type: 'object',
         }),
       });
-    });
+    }, 30_000);
 
     test('should list bases, tables, and records', async () => {
       // First get bases
@@ -332,7 +332,7 @@ describe.each([
         // eslint-disable-next-line no-console
         console.warn('Skipping list_records test as no tables found');
       }
-    });
+    }, 30_000);
 
     test('should list and read resources', async () => {
       // First list resources
@@ -380,6 +380,6 @@ describe.each([
         name: expect.any(String),
         fields: expect.any(Array),
       });
-    });
+    }, 30_000);
   });
 });


### PR DESCRIPTION
## Summary
- Extends timeout to 30 seconds for integration tests that interact with external Airtable API
- Prevents flaky test failures due to network latency or API response times

🤖 Generated with [Claude Code](https://claude.ai/code)