### PR TITLE
Add MCP registry publishing to CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,10 +72,11 @@ jobs:
         run: npm run build --if-present
       - name: Build MCP Bundle
         run: npm run build:mcpb
-      - name: Update server.json version
+      - name: Update server.json version and SHA256
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          sed "s/{{VERSION}}/$VERSION/g" server.json > server.json.tmp
+          MCPB_FILE_SHA256=$(sha256sum airtable-mcp-server.mcpb | cut -d' ' -f1)
+          sed "s/{{VERSION}}/$VERSION/g; s/{{MCPB_FILE_SHA256}}/$MCPB_FILE_SHA256/g" server.json > server.json.tmp
           mv server.json.tmp server.json
       - name: Publish to NPM
         run: npm publish
@@ -111,9 +112,10 @@ jobs:
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # - name: Install MCP Publisher
-      #   run: # TODO: Install mcp-publisher
-      # - name: Login to MCP Registry
-      #   run: mcp-publisher login github-oidc
-      # - name: Publish to MCP Registry
-      #   run: mcp-publisher publish
+      - name: Install MCP Publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.0.0/mcp-publisher_1.0.0_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+      - name: Login to MCP Registry
+        run: ./mcp-publisher login github-oidc
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/server.json
+++ b/server.json
@@ -1,19 +1,17 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
   "name": "io.github.domdomegg/airtable-mcp-server",
-  "description": "A Model Context Protocol server that provides read and write access to Airtable databases. This server enables LLMs to inspect database schemas, then read and write records.",
+  "description": "Read and write access to Airtable database schemas, tables, and records.",
   "status": "active",
   "repository": {
     "url": "https://github.com/domdomegg/airtable-mcp-server.git",
     "source": "github"
   },
-  "version_detail": {
-    "version": "{{VERSION}}"
-  },
+  "version": "{{VERSION}}",
   "packages": [
     {
-      "registry_name": "npm",
-      "name": "airtable-mcp-server",
+      "registry_type": "npm",
+      "identifier": "airtable-mcp-server",
       "version": "{{VERSION}}",
       "runtime_hint": "npx",
       "environment_variables": [
@@ -26,18 +24,10 @@
       ]
     },
     {
-      "registry_name": "docker",
-      "name": "domdomegg/airtable-mcp-server",
+      "registry_type": "docker",
+      "identifier": "domdomegg/airtable-mcp-server",
       "version": "{{VERSION}}",
       "runtime_hint": "docker",
-      "package_arguments": [
-        {
-          "type": "positional",
-          "value_hint": "AIRTABLE_API_KEY",
-          "description": "Airtable API key will be passed as environment variable",
-          "is_required": true
-        }
-      ],
       "environment_variables": [
         {
           "name": "AIRTABLE_API_KEY",
@@ -48,20 +38,11 @@
       ]
     },
     {
-      "registry_name": "mcpb",
-      "name": "airtable-mcp-server",
+      "registry_type": "mcpb",
+      "identifier": "airtable-mcp-server",
       "version": "{{VERSION}}",
       "download_url": "https://github.com/domdomegg/airtable-mcp-server/releases/download/v{{VERSION}}/airtable-mcp-server.mcpb",
-      "user_config": [
-        {
-          "name": "api_key",
-          "type": "string",
-          "title": "Airtable API Key",
-          "description": "Your Airtable personal access token. Should have at least schema.bases:read and data.records:read permissions, and optionally the corresponding write permissions.",
-          "is_required": true,
-          "is_secret": true
-        }
-      ]
+      "file_sha256": "{{MCPB_FILE_SHA256}}"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add automated publishing to MCP registry when releases are created
- Use pre-built mcp-publisher binary for faster CI runs
- Update server.json to include SHA256 hash for MCPB package validation