### PR TITLE
Migrate to MCP SDK v2 API

### DIFF
--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -256,10 +256,8 @@ describe.each([
 			expect(basesResult).toMatchObject({
 				content: [{
 					type: 'text',
-					mimeType: 'application/json',
 					text: expect.any(String),
 				}],
-				isError: false,
 			});
 
 			const bases = JSON.parse(basesResult.content[0]!.text as string);
@@ -289,10 +287,8 @@ describe.each([
 			expect(tablesResult).toMatchObject({
 				content: [{
 					type: 'text',
-					mimeType: 'application/json',
 					text: expect.any(String),
 				}],
-				isError: false,
 			});
 
 			const tables = JSON.parse(tablesResult.content[0]!.text as string);
@@ -324,10 +320,8 @@ describe.each([
 				expect(recordsResult).toMatchObject({
 					content: [{
 						type: 'text',
-						mimeType: 'application/json',
 						text: expect.any(String),
 					}],
-					isError: false,
 				});
 
 				const records = JSON.parse(recordsResult.content[0]!.text as string);

--- a/src/mcpServer.test.ts
+++ b/src/mcpServer.test.ts
@@ -115,6 +115,7 @@ describe('AirtableMCPServer', () => {
 					uri: 'airtable://base1/tbl1/schema',
 					mimeType: 'application/json',
 					name: 'Test Base: Test Table schema',
+					description: 'Table schemas from Airtable bases',
 				}],
 			});
 		});
@@ -182,12 +183,10 @@ describe('AirtableMCPServer', () => {
 			expect(response.result).toEqual({
 				content: [{
 					type: 'text',
-					mimeType: 'application/json',
 					text: JSON.stringify([
 						{id: 'rec1', fields: {name: 'Test Record'}},
 					]),
 				}],
-				isError: false,
 			});
 		});
 	});


### PR DESCRIPTION
## Summary

This PR migrates the codebase from MCP SDK v1 to v2, adopting the new simplified API patterns:

- Replaced `Server` with `McpServer` class
- Migrated from manual request handlers to `registerTool()` and `registerResource()` methods
- Implemented `ResourceTemplate` for dynamic resource handling
- Simplified response formats by removing redundant `mimeType` and `isError` fields
- Updated schema validation to use new SDK patterns with zod

The migration maintains all existing functionality while aligning with the latest MCP SDK best practices.