### PR TITLE
Update server.json to MCP registry schema 2025-10-17

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,8 +1,7 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
   "name": "io.github.domdomegg/airtable-mcp-server",
   "description": "Read and write access to Airtable database schemas, tables, and records.",
-  "status": "active",
   "repository": {
     "url": "https://github.com/domdomegg/airtable-mcp-server.git",
     "source": "github"
@@ -10,16 +9,16 @@
   "version": "{{VERSION}}",
   "packages": [
     {
-      "registry_type": "npm",
+      "registryType": "npm",
       "identifier": "airtable-mcp-server",
       "version": "{{VERSION}}",
-      "runtime_hint": "npx",
-      "environment_variables": [
+      "runtimeHint": "npx",
+      "environmentVariables": [
         {
           "name": "AIRTABLE_API_KEY",
           "description": "Airtable personal access token (e.g., pat123.abc123). Create at https://airtable.com/create/tokens/new with scopes: schema.bases:read, data.records:read, and optionally schema.bases:write and data.records:write.",
-          "is_required": true,
-          "is_secret": true
+          "isRequired": true,
+          "isSecret": true
         }
       ],
       "transport": {
@@ -27,16 +26,16 @@
       }
     },
     {
-      "registry_type": "oci",
+      "registryType": "oci",
       "identifier": "domdomegg/airtable-mcp-server",
       "version": "{{VERSION}}",
-      "runtime_hint": "docker",
-      "environment_variables": [
+      "runtimeHint": "docker",
+      "environmentVariables": [
         {
           "name": "AIRTABLE_API_KEY",
           "description": "Airtable personal access token (e.g., pat123.abc123). Create at https://airtable.com/create/tokens/new with scopes: schema.bases:read, data.records:read, and optionally schema.bases:write and data.records:write.",
-          "is_required": true,
-          "is_secret": true
+          "isRequired": true,
+          "isSecret": true
         }
       ],
       "transport": {
@@ -44,10 +43,10 @@
       }
     },
     {
-      "registry_type": "mcpb",
+      "registryType": "mcpb",
       "identifier": "https://github.com/domdomegg/airtable-mcp-server/releases/download/v{{VERSION}}/airtable-mcp-server.mcpb",
       "version": "{{VERSION}}",
-      "file_sha256": "{{MCPB_FILE_SHA256}}",
+      "fileSha256": "{{MCPB_FILE_SHA256}}",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary

Updates `server.json` to comply with the latest MCP registry schema specification (2025-10-17).

## Changes

- Update schema URL from `2025-07-09` to `2025-10-17`
- Remove deprecated `status` field (no longer in schema)
- Convert all snake_case fields to camelCase as required by new schema:
  - `registry_type` → `registryType`
  - `runtime_hint` → `runtimeHint`
  - `environment_variables` → `environmentVariables`
  - `is_required` → `isRequired`
  - `is_secret` → `isSecret`
  - `file_sha256` → `fileSha256`

Schema validation confirmed successful against the official 2025-10-17 schema.