### PR TITLE
Fix smithery.yaml entry point to resolve OAuth metadata startup error

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -14,4 +14,4 @@ startCommand:
   commandFunction:
     # A function that produces the CLI command to start the MCP on stdio.
     |-
-    (config) => ({command: 'node', args: ['dist/index.js'], env: {AIRTABLE_API_KEY: config.airtableApiKey}})
+    (config) => ({command: 'node', args: ['dist/main.js'], env: {AIRTABLE_API_KEY: config.airtableApiKey}})


### PR DESCRIPTION
The smithery.yaml was configured to start dist/index.js, which only exports the createServer function but doesn't actually start the MCP server. This caused the server process to fail during startup when handling OAuth metadata requests in Lambda environments.

Changed the entry point to dist/main.js which properly initializes the server with stdio/HTTP transports. This fixes the "tsc: command not found" error that occurred when the Lambda function tried to start the server process.