### PR TITLE
feat: Add destructiveHint annotations to write tools

### DIFF
--- a/src/tools/create-comment.ts
+++ b/src/tools/create-comment.ts
@@ -33,6 +33,7 @@ export function registerCreateComment(server: McpServer, ctx: ToolContext): void
 			outputSchema,
 			annotations: {
 				readOnlyHint: false,
+				destructiveHint: false,
 			},
 		},
 		async (args) => {

--- a/src/tools/create-field.ts
+++ b/src/tools/create-field.ts
@@ -23,6 +23,7 @@ export function registerCreateField(server: McpServer, ctx: ToolContext): void {
 			outputSchema,
 			annotations: {
 				readOnlyHint: false,
+				destructiveHint: false,
 			},
 		},
 		async (args) => {

--- a/src/tools/create-record.ts
+++ b/src/tools/create-record.ts
@@ -22,6 +22,7 @@ export function registerCreateRecord(server: McpServer, ctx: ToolContext): void 
 			outputSchema,
 			annotations: {
 				readOnlyHint: false,
+				destructiveHint: false,
 			},
 		},
 		async (args) => {

--- a/src/tools/create-table.ts
+++ b/src/tools/create-table.ts
@@ -23,6 +23,7 @@ export function registerCreateTable(server: McpServer, ctx: ToolContext): void {
 			outputSchema,
 			annotations: {
 				readOnlyHint: false,
+				destructiveHint: false,
 			},
 		},
 		async (args) => {

--- a/src/tools/delete-records.ts
+++ b/src/tools/delete-records.ts
@@ -23,6 +23,7 @@ export function registerDeleteRecords(server: McpServer, ctx: ToolContext): void
 			outputSchema,
 			annotations: {
 				readOnlyHint: false,
+				destructiveHint: true,
 			},
 		},
 		async (args) => {

--- a/src/tools/update-field.ts
+++ b/src/tools/update-field.ts
@@ -23,6 +23,7 @@ export function registerUpdateField(server: McpServer, ctx: ToolContext): void {
 			outputSchema,
 			annotations: {
 				readOnlyHint: false,
+				destructiveHint: true,
 			},
 		},
 		async (args) => {

--- a/src/tools/update-records.ts
+++ b/src/tools/update-records.ts
@@ -27,6 +27,7 @@ export function registerUpdateRecords(server: McpServer, ctx: ToolContext): void
 			outputSchema,
 			annotations: {
 				readOnlyHint: false,
+				destructiveHint: true,
 			},
 		},
 		async (args) => {

--- a/src/tools/update-table.ts
+++ b/src/tools/update-table.ts
@@ -22,6 +22,7 @@ export function registerUpdateTable(server: McpServer, ctx: ToolContext): void {
 			outputSchema,
 			annotations: {
 				readOnlyHint: false,
+				destructiveHint: true,
 			},
 		},
 		async (args) => {


### PR DESCRIPTION
## Summary

Adds `destructiveHint` annotations to all 8 write tools to help LLMs better understand tool behavior and make safer decisions about tool execution.

## Changes

| Tool | destructiveHint | Reason |
|------|-----------------|--------|
| `delete_records` | `true` | Deletes data permanently |
| `update_records` | `true` | Modifies existing records |
| `update_table` | `true` | Modifies existing table |
| `update_field` | `true` | Modifies existing field |
| `create_record` | `false` | Creates new data only (additive) |
| `create_table` | `false` | Creates new data only (additive) |
| `create_field` | `false` | Creates new data only (additive) |
| `create_comment` | `false` | Creates new data only (additive) |

This completes the annotation set - tools already have `title` and `readOnlyHint`.

## Why This Matters

Per [MCP Tool Annotations Spec](https://modelcontextprotocol.io/specification/2025-06-18/server/tools):
- `destructiveHint: true` indicates a tool "may perform destructive updates" (modify or delete)
- `destructiveHint: false` indicates a tool "performs only additive updates" (create new only)

This enables MCP clients to:
- Show appropriate warnings for destructive operations
- Auto-approve safe create operations
- Make better decisions about operation sequencing

## Testing

- [x] Build succeeds (`npm run build`)
- [x] Linter passes (`npm run lint`)
- [x] All tests pass (`npm test`) - 52 passed, 6 skipped
- [x] Annotation values verified via grep

🤖 Generated with [Claude Code](https://claude.com/claude-code)