### PR TITLE
Fix HTTP transport cross-client response misrouting

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -25,9 +25,9 @@ function setupSignalHandlers(cleanup: () => Promise<void>): void {
 
 	const transport = process.env.MCP_TRANSPORT || 'stdio';
 	const airtableService = new AirtableService(apiKey);
-	const server = createServer({airtableService});
 
 	if (transport === 'stdio') {
+		const server = createServer({airtableService});
 		setupSignalHandlers(async () => server.close());
 
 		const stdioTransport = new StdioServerTransport();
@@ -36,16 +36,19 @@ function setupSignalHandlers(cleanup: () => Promise<void>): void {
 		const app = express();
 		app.use(express.json({limit: '20mb'}));
 
-		const httpTransport = new StreamableHTTPServerTransport({
-			sessionIdGenerator: undefined,
-			enableJsonResponse: true,
-		});
-
+		// Stateless: fresh server + transport per request — sharing either misroutes responses on concurrent requests with colliding JSON-RPC IDs (GHSA-345p-7cg4-v4c7).
 		app.post('/mcp', async (req, res) => {
+			const server = createServer({airtableService});
+			const httpTransport = new StreamableHTTPServerTransport({
+				sessionIdGenerator: undefined,
+				enableJsonResponse: true,
+			});
+			res.on('close', () => {
+				void server.close();
+			});
+			await server.connect(httpTransport);
 			await httpTransport.handleRequest(req, res, req.body);
 		});
-
-		await server.connect(httpTransport);
 
 		const port = parseInt(process.env.PORT || '3000', 10);
 		const httpServer = app.listen(port, () => {
@@ -54,7 +57,6 @@ function setupSignalHandlers(cleanup: () => Promise<void>): void {
 		});
 
 		setupSignalHandlers(async () => {
-			await server.close();
 			httpServer.close();
 		});
 	} else {


### PR DESCRIPTION
## Summary

`src/main.ts` previously created a single `StreamableHTTPServerTransport` (stateless, `sessionIdGenerator: undefined`) and a single `McpServer`, then reused both across every `/mcp` request. This is the exact pattern called out by [GHSA-345p-7cg4-v4c7](https://github.com/advisories/GHSA-345p-7cg4-v4c7): with two concurrent clients, JSON-RPC IDs collide (the SDK's default client uses an incrementing counter starting at 0), and the transport's internal `requestId → res` map gets overwritten — so a tool result for client A can be written to client B's HTTP response.

This PR moves construction inside the `app.post('/mcp', ...)` handler, matching the advisory's prescribed workaround. The shared `AirtableService` is fine to keep at module scope — it's just an API client wrapper. `res.on('close', ...)` ensures the per-request server is closed when the connection ends.

stdio mode is unchanged.

This is an alternative to #102, which only bumps the SDK. Bumping alone doesn't fix the architecture — in SDK ≥1.26 the runtime guards turn silent misrouting into a thrown error on the second concurrent request, but the server still doesn't actually serve concurrent clients correctly. A proper fix needs the per-request construction; the SDK bump is independent and can be done separately.

## Test plan

- [x] `npm run build`
- [x] `npm test` — 55 passed, 6 skipped (the existing HTTP transport tests in `src/e2e.test.ts` exercise the new per-request construction path)
- [x] `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)