### PR TITLE
docs: fix CI builds link in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Keep the token handy, you'll need it in the next step. It should look something 
 
 #### (Advanced) Alternative: Via manual .mcpb installation
 
-1. Find the latest mcpb build in [the GitHub Actions history](https://github.com/domdomegg/airtable-mcp-server/actions/workflows/mcpb.yaml?query=branch%3Amaster) (the top one)
+1. Find the latest mcpb build in [the GitHub Actions history](https://github.com/domdomegg/airtable-mcp-server/actions/workflows/ci.yaml?query=branch%3Amaster) (the top one)
 2. In the 'Artifacts' section, download the `airtable-mcp-server-mcpb` file
 3. Rename the `.zip` file to `.mcpb`
 4. Double-click the `.mcpb` file to open with Claude Desktop


### PR DESCRIPTION
The README install section linked to `actions/workflows/mcpb.yaml` which no longer exists — only `ci.yaml` and `auto-dependabot.yaml` are in `.github/workflows/`. Updated to point at `ci.yaml`. Same class of fix as domdomegg/computer-use-mcp#65/#66.