### PR TITLE
feat: pass through choices to update_field for singleSelect / multipleSelects

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,13 +212,18 @@ Create either a global (`~/.cursor/mcp.json`) or project-specific (`.cursor/mcp.
     - `options` (object, optional): Field-specific options
 
 - **update_field**
-  - Updates a field's name or description
+  - Updates a field's name, description, or type-specific options (e.g. choices on singleSelect / multipleSelects)
   - Input parameters:
     - `baseId` (string, required): The ID of the Airtable base
     - `tableId` (string, required): The ID of the table
     - `fieldId` (string, required): The ID of the field
     - `name` (string, optional): New name for the field
     - `description` (string, optional): New description for the field
+    - `options` (object, optional): Field type-specific options
+      - `choices` (array, optional): For singleSelect / multipleSelects fields. Pass the full desired set of choices — existing choices that are omitted will be deleted. Each choice has:
+        - `id` (string, optional): The ID of an existing choice. Include to retain or rename/recolor it; omit when creating a new choice
+        - `name` (string, required): The display name of the choice
+        - `color` (string, optional): The color of the choice (e.g. `"blueLight2"`, `"greenBright"`)
 
 - **create_comment**
   - Creates a comment on a record

--- a/src/airtableService.test.ts
+++ b/src/airtableService.test.ts
@@ -404,6 +404,78 @@ describe('AirtableService', () => {
 			});
 		});
 
+		describe('field operations', () => {
+			const mockBaseId = 'base123';
+			const mockTableId = 'table123';
+			const mockFieldId = 'fld123';
+
+			test('updates a field name and description', async () => {
+				const mockField = {
+					id: mockFieldId,
+					name: 'Status',
+					description: 'Workflow status',
+					type: 'singleLineText',
+				};
+				mockFetch.mockResolvedValueOnce({
+					ok: true,
+					text: async () => Promise.resolve(JSON.stringify(mockField)),
+				});
+
+				const result = await service.updateField(mockBaseId, mockTableId, mockFieldId, {
+					name: 'Status',
+					description: 'Workflow status',
+				});
+
+				expect(mockFetch).toHaveBeenCalledWith(
+					`${mockBaseUrl}/v0/meta/bases/${mockBaseId}/tables/${mockTableId}/fields/${mockFieldId}`,
+					expect.objectContaining({
+						method: 'PATCH',
+						body: JSON.stringify({name: 'Status', description: 'Workflow status'}),
+					}),
+				);
+				expect(result).toEqual(mockField);
+			});
+
+			test('forwards options.choices for singleSelect / multipleSelects fields', async () => {
+				const mockField = {
+					id: mockFieldId,
+					name: 'Status',
+					type: 'singleSelect',
+					options: {
+						choices: [
+							{id: 'sel1', name: 'Todo', color: 'grayLight2'},
+							{id: 'sel2', name: 'In progress', color: 'yellowLight2'},
+							{name: 'Done', color: 'greenLight2'},
+						],
+					},
+				};
+				mockFetch.mockResolvedValueOnce({
+					ok: true,
+					text: async () => Promise.resolve(JSON.stringify(mockField)),
+				});
+
+				const updates = {
+					options: {
+						choices: [
+							{id: 'sel1', name: 'Todo', color: 'grayLight2'},
+							{id: 'sel2', name: 'In progress', color: 'yellowLight2'},
+							{name: 'Done', color: 'greenLight2'},
+						],
+					},
+				};
+				const result = await service.updateField(mockBaseId, mockTableId, mockFieldId, updates);
+
+				expect(mockFetch).toHaveBeenCalledWith(
+					`${mockBaseUrl}/v0/meta/bases/${mockBaseId}/tables/${mockTableId}/fields/${mockFieldId}`,
+					expect.objectContaining({
+						method: 'PATCH',
+						body: JSON.stringify(updates),
+					}),
+				);
+				expect(result).toEqual(mockField);
+			});
+		});
+
 		describe('comment operations', () => {
 			const mockBaseId = 'base123';
 			const mockTableId = 'table123';

--- a/src/airtableService.ts
+++ b/src/airtableService.ts
@@ -184,7 +184,13 @@ export class AirtableService implements IAirtableService {
 		baseId: string,
 		tableId: string,
 		fieldId: string,
-		updates: {name?: string; description?: string},
+		updates: {
+			name?: string;
+			description?: string;
+			options?: {
+				choices?: {id?: string; name: string; color?: string}[];
+			};
+		},
 	): Promise<Field> {
 		return this.fetchFromAPI(
 			`/v0/meta/bases/${baseId}/tables/${tableId}/fields/${fieldId}`,

--- a/src/mcpServer.test.ts
+++ b/src/mcpServer.test.ts
@@ -347,6 +347,75 @@ describe('AirtableMCPServer', () => {
 			});
 		});
 
+		test('handles update_field tool call with name and description', async () => {
+			await sendRequest({
+				jsonrpc: '2.0',
+				id: '1',
+				method: 'tools/call',
+				params: {
+					name: 'update_field',
+					arguments: {
+						baseId: 'base1',
+						tableId: 'tbl1',
+						fieldId: 'fld1',
+						name: 'Renamed',
+						description: 'Updated description',
+					},
+				},
+			});
+
+			expect(mockAirtableService.updateField).toHaveBeenCalledWith(
+				'base1',
+				'tbl1',
+				'fld1',
+				{
+					name: 'Renamed',
+					description: 'Updated description',
+					options: undefined,
+				},
+			);
+		});
+
+		test('handles update_field tool call with options.choices for select fields', async () => {
+			await sendRequest({
+				jsonrpc: '2.0',
+				id: '1',
+				method: 'tools/call',
+				params: {
+					name: 'update_field',
+					arguments: {
+						baseId: 'base1',
+						tableId: 'tbl1',
+						fieldId: 'fld1',
+						options: {
+							choices: [
+								{id: 'sel1', name: 'Todo', color: 'grayLight2'},
+								{name: 'In progress', color: 'yellowLight2'},
+								{id: 'sel2', name: 'Done', color: 'greenLight2'},
+							],
+						},
+					},
+				},
+			});
+
+			expect(mockAirtableService.updateField).toHaveBeenCalledWith(
+				'base1',
+				'tbl1',
+				'fld1',
+				{
+					name: undefined,
+					description: undefined,
+					options: {
+						choices: [
+							{id: 'sel1', name: 'Todo', color: 'grayLight2'},
+							{name: 'In progress', color: 'yellowLight2'},
+							{id: 'sel2', name: 'Done', color: 'greenLight2'},
+						],
+					},
+				},
+			);
+		});
+
 		test('handles list_comments tool call with pagination', async () => {
 			const response = await sendRequest({
 				jsonrpc: '2.0',

--- a/src/tools/update-field.ts
+++ b/src/tools/update-field.ts
@@ -8,17 +8,43 @@ const outputSchema = z.object({
 	field: z.record(z.string(), z.unknown()),
 });
 
+const choiceSchema = z.object({
+	id: z
+		.string()
+		.optional()
+		.describe('The ID of an existing choice. Include to retain or rename/recolor it; omit when creating a new choice.'),
+	name: z.string().describe('The display name of the choice.'),
+	color: z
+		.string()
+		.optional()
+		.describe('The color of the choice (e.g. "blueLight2", "greenBright"). Optional when creating a new choice.'),
+});
+
+const updateFieldOptionsSchema = z
+	.object({
+		choices: z
+			.array(choiceSchema)
+			.optional()
+			.describe(
+				'For singleSelect / multipleSelects fields. Pass the full desired set of choices — '
+				+ 'existing choices that are omitted will be deleted. Identify existing choices by their `id`; '
+				+ 'new choices are created when no `id` is provided.',
+			),
+	})
+	.describe('Field type-specific options. Currently `choices` is supported for singleSelect / multipleSelects fields.');
+
 export function registerUpdateField(server: McpServer, ctx: ToolContext): void {
 	server.registerTool(
 		'update_field',
 		{
 			title: 'Update Field',
-			description: 'Update a field\'s name or description',
+			description: 'Update a field\'s name, description, or type-specific options (e.g. choices on singleSelect / multipleSelects)',
 			inputSchema: {
 				...tableId,
 				fieldId: z.string().describe('The ID of the field'),
 				name: z.string().optional().describe('New name for the field'),
 				description: z.string().optional().describe('New description for the field'),
+				options: updateFieldOptionsSchema.optional(),
 			},
 			outputSchema,
 			annotations: {
@@ -34,6 +60,7 @@ export function registerUpdateField(server: McpServer, ctx: ToolContext): void {
 				{
 					name: args.name,
 					description: args.description,
+					options: args.options,
 				},
 			);
 			return jsonResult(outputSchema.parse({field}));

--- a/src/types.ts
+++ b/src/types.ts
@@ -582,7 +582,7 @@ export type IAirtableService = {
 	createTable(baseId: string, name: string, fields: Field[], description?: string): Promise<Table>;
 	updateTable(baseId: string, tableId: string, updates: {name?: string | undefined; description?: string | undefined}): Promise<Table>;
 	createField(baseId: string, tableId: string, field: Field): Promise<Field & {id: string}>;
-	updateField(baseId: string, tableId: string, fieldId: string, updates: {name?: string | undefined; description?: string | undefined}): Promise<Field & {id: string}>;
+	updateField(baseId: string, tableId: string, fieldId: string, updates: {name?: string | undefined; description?: string | undefined; options?: {choices?: {id?: string; name: string; color?: string}[] | undefined} | undefined}): Promise<Field & {id: string}>;
 	searchRecords(baseId: string, tableId: string, searchTerm: string, fieldIds?: string[], maxRecords?: number, view?: string): Promise<AirtableRecord[]>;
 	createComment(baseId: string, tableId: string, recordId: string, text: string, parentCommentId?: string): Promise<Comment>;
 	listComments(baseId: string, tableId: string, recordId: string, pageSize?: number, offset?: string): Promise<ListCommentsResponse>;


### PR DESCRIPTION
## Summary

`update_field` currently only accepts `name` and `description`, but the underlying Airtable Meta API endpoint (`PATCH /v0/meta/bases/{baseId}/tables/{tableId}/fields/{fieldId}`) supports updating `options.choices` on `singleSelect` and `multipleSelects` fields. This is a routine operation — coloring chips, renaming options, adding new options, retiring old ones — that previously required dropping out of the MCP and hitting the Airtable API directly.

This PR adds an optional `options.choices` parameter to `update_field` and forwards it to the Airtable API.

### Behavior

- `choices[].id` (optional): supply to retain or rename/recolor an existing choice; omit to create a new one.
- `choices[].name` (required): display name of the choice.
- `choices[].color` (optional): e.g. `"blueLight2"`, `"greenBright"`.
- Per the Airtable API, the request must include the full desired set of choices — existing choices that are omitted will be deleted. This is documented in the tool description so the LLM passes through the existing choices it wants to keep.

### Changes

- `src/tools/update-field.ts` — add `options` to the input schema and pass it through to the service.
- `src/airtableService.ts` — widen `updateField` `updates` type to accept `options.choices`.
- `src/types.ts` — update `IAirtableService.updateField` signature.
- `src/airtableService.test.ts` — unit test that `options.choices` is forwarded in the PATCH body.
- `src/mcpServer.test.ts` — MCP-level test asserting the tool plumbs `options` to the service.
- `README.md` — document the new parameter.

## Test plan

- [x] Added unit tests for the service-level call (name/description + options.choices).
- [x] Added MCP-level tests covering both branches.
- [ ] CI (lint, build, vitest on lts + current node) passes on this PR.