### PR TITLE
feat: add fields parameter to list_records tool

### DIFF
--- a/src/airtableService.ts
+++ b/src/airtableService.ts
@@ -81,6 +81,13 @@ export class AirtableService implements IAirtableService {
 				});
 			}
 
+			// Add fields parameter if provided
+			if (options.fields && options.fields.length > 0) {
+				options.fields.forEach((field) => {
+					queryParams.append('fields[]', field);
+				});
+			}
+
 			// eslint-disable-next-line no-await-in-loop
 			const response = await this.fetchFromAPI(
 				`/v0/${baseId}/${tableId}?${queryParams.toString()}`,

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -344,6 +344,30 @@ describe.each([
 			}
 		}, 30_000);
 
+		test('should only return the requested fields when listing records', async () => {
+			const result = await client.sendRequest<CallToolResult>({
+				jsonrpc: '2.0',
+				id: '1',
+				method: 'tools/call',
+				params: {
+					name: 'list_records',
+					arguments: {
+						baseId: 'appTc3EH4VcwliOCf',
+						tableId: 'tblya8yQZYB9HXrk6',
+						maxRecords: 3,
+						// 'Patient Name' by name, 'Age' by field id
+						fields: ['Patient Name', 'fldozKLQ9qhG3FgIB'],
+					},
+				},
+			});
+
+			const {records} = JSON.parse(result.content[0]!.text as string);
+			expect(records.length).toBeGreaterThan(0);
+			for (const record of records) {
+				expect(Object.keys(record.fields).sort()).toEqual(['Age', 'Patient Name']);
+			}
+		}, 30_000);
+
 		test('should list comments on a record', async () => {
 			const result = await client.sendRequest<CallToolResult>({
 				jsonrpc: '2.0',

--- a/src/tools/list-records.ts
+++ b/src/tools/list-records.ts
@@ -26,6 +26,7 @@ export function registerListRecords(server: McpServer, ctx: ToolContext): void {
 					field: z.string(),
 					direction: z.enum(['asc', 'desc']).optional(),
 				})).optional().describe('A list of sort objects that specifies how the records will be ordered'),
+				fields: z.array(z.string()).optional().describe('An array of field names or IDs to include in the response'),
 			},
 			outputSchema,
 			annotations: {
@@ -41,6 +42,7 @@ export function registerListRecords(server: McpServer, ctx: ToolContext): void {
 					maxRecords: args.maxRecords,
 					filterByFormula: args.filterByFormula,
 					sort: args.sort,
+					fields: args.fields,
 				},
 			);
 			return jsonResult(outputSchema.parse({records}));

--- a/src/tools/list-records.ts
+++ b/src/tools/list-records.ts
@@ -26,7 +26,7 @@ export function registerListRecords(server: McpServer, ctx: ToolContext): void {
 					field: z.string(),
 					direction: z.enum(['asc', 'desc']).optional(),
 				})).optional().describe('A list of sort objects that specifies how the records will be ordered'),
-				fields: z.array(z.string()).optional().describe('An array of field names or IDs to include in the response'),
+				fields: z.array(z.string()).optional().describe('An array of field names or IDs to include in the response. Omit this to return all fields, which is usually what you want. Only set it if the table has many fields and you don\'t need most of them, AND you already know the exact field names or IDs (e.g. from describe_table) - guessing them will silently return the wrong data.'),
 			},
 			outputSchema,
 			annotations: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -404,6 +404,7 @@ export const ListRecordsArgsSchema = z.object({
 	view: z.string().optional().describe('View name or ID to use for filtering and sorting records. If provided, the view\'s filters and sorts will be applied.'),
 	maxRecords: z.number().optional().describe('Maximum number of records to return. Defaults to 100.'),
 	filterByFormula: z.string().optional().describe('Airtable formula to filter records'),
+	fields: z.array(z.string()).optional().describe('An array of field names or IDs to include in the response'),
 	sort: z.array(z.object({
 		field: z.string().describe('Field name to sort by'),
 		direction: z.enum(['asc', 'desc']).optional().describe('Sort direction. Defaults to asc (ascending)'),
@@ -569,6 +570,7 @@ export type ListRecordsOptions = {
 	maxRecords?: z.infer<typeof ListRecordsArgsSchema.shape.maxRecords>;
 	filterByFormula?: z.infer<typeof ListRecordsArgsSchema.shape.filterByFormula>;
 	sort?: z.infer<typeof ListRecordsArgsSchema.shape.sort>;
+	fields?: z.infer<typeof ListRecordsArgsSchema.shape.fields>;
 };
 
 export type IAirtableService = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -404,7 +404,7 @@ export const ListRecordsArgsSchema = z.object({
 	view: z.string().optional().describe('View name or ID to use for filtering and sorting records. If provided, the view\'s filters and sorts will be applied.'),
 	maxRecords: z.number().optional().describe('Maximum number of records to return. Defaults to 100.'),
 	filterByFormula: z.string().optional().describe('Airtable formula to filter records'),
-	fields: z.array(z.string()).optional().describe('An array of field names or IDs to include in the response'),
+	fields: z.array(z.string()).optional().describe('An array of field names or IDs to include in the response. Omit this to return all fields, which is usually what you want. Only set it if the table has many fields and you don\'t need most of them, AND you already know the exact field names or IDs (e.g. from describe_table) - guessing them will silently return the wrong data.'),
 	sort: z.array(z.object({
 		field: z.string().describe('Field name to sort by'),
 		direction: z.enum(['asc', 'desc']).optional().describe('Sort direction. Defaults to asc (ascending)'),


### PR DESCRIPTION
Fixes #75

Exposes the `fields[]` API parameter to the `list_records` tool so agents can specify which fields to retrieve, avoiding the cost of fetching all fields on tables with many linked/lookup fields.

Files modified:
- src/types.ts: added fields to schema and type
- src/airtableService.ts: added fields param to API call
- src/tools/list-records.ts: added fields to inputSchema