### PR TITLE
Fix Claude Desktop JSON config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Keep the token handy, you'll need it in the next step. It should look something 
         "airtable-mcp-server"
       ],
       "env": {
-        "AIRTABLE_API_KEY": "pat123.abc123",
+        "AIRTABLE_API_KEY": "pat123.abc123"
       }
     }
   }


### PR DESCRIPTION
Small docs fix for the Claude Desktop JSON configuration example.

The `AIRTABLE_API_KEY` line had a trailing comma, which makes the copied snippet invalid JSON. The Cursor and Cline examples already omit that comma, so this keeps the three setup examples consistent.

I also checked the README's three fenced `json` blocks with Python `json.loads`; all parse after this change.

No code behavior changed.
